### PR TITLE
Harden release workflow and grading failure signaling

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,29 @@ on:
       - main    # change if your default branch is different
 
 jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Sync dependencies
+        run: uv sync --extra dev
+
+      - name: Run repository hygiene checks
+        run: bash scripts/check_repo_hygiene.sh
+
+      - name: Run tests
+        run: uv run pytest -q
+
   release:
+    needs: checks
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/Autograder/__init__.py
+++ b/Autograder/__init__.py
@@ -5,23 +5,39 @@ import re
 import sys
 
 
+def _ensure_writable_log_dir(path: str) -> bool:
+  try:
+    os.makedirs(path, exist_ok=True)
+  except OSError:
+    return False
+  return os.path.isdir(path) and os.access(path, os.W_OK)
+
+
 def setup_logging() -> None:
   if "LOG_DIR" not in os.environ:
-    default_log_dir = "/var/log/grading"
-    if os.path.isdir(default_log_dir) and os.access(default_log_dir,
-                                                    os.W_OK):
-      os.environ["LOG_DIR"] = default_log_dir
-    else:
-      try:
-        os.makedirs(default_log_dir, exist_ok=True)
-        os.environ["LOG_DIR"] = default_log_dir
-      except OSError:
-        fallback_dir = os.getcwd()
-        os.environ["LOG_DIR"] = fallback_dir
+    candidates = [
+      "/var/log/grading",
+      os.path.abspath(os.path.expanduser("~/.autograder/logs")),
+      "/tmp/autograder/logs",
+    ]
+    selected = None
+    for candidate in candidates:
+      if _ensure_writable_log_dir(candidate):
+        selected = candidate
+        break
+
+    if selected is not None:
+      os.environ["LOG_DIR"] = selected
+      if selected != candidates[0]:
         print(
-          f"Logging: unable to use {default_log_dir}; have you created it with write permissions? "
-          f"Falling back to {fallback_dir}.",
+          f"Logging: unable to use {candidates[0]}; falling back to {selected}.",
           file=sys.stderr)
+    else:
+      # Last-resort fallback keeps logging usable without polluting repo/run dirs.
+      os.environ["LOG_DIR"] = "/tmp"
+      print(
+        "Logging: unable to create dedicated log directory; falling back to /tmp.",
+        file=sys.stderr)
 
   config_path = os.path.join(os.path.dirname(__file__), 'logging.yaml')
   if os.path.exists(config_path):

--- a/Autograder/grade_assignments.py
+++ b/Autograder/grade_assignments.py
@@ -90,8 +90,19 @@ def load_and_validate_config(yaml_path: str) -> RunConfig:
     Raises:
         SystemExit: If the configuration is invalid
     """
-    with open(yaml_path) as fid:
-        raw_config = yaml.safe_load(fid)
+    try:
+        with open(yaml_path) as fid:
+            raw_config = yaml.safe_load(fid)
+    except yaml.YAMLError as e:
+        raise SystemExit(
+            f"Invalid config file '{yaml_path}': YAML parse error: {e}. "
+            "See documentation/instructor_onboarding.md for supported schema/examples."
+        ) from e
+    except OSError as e:
+        raise SystemExit(
+            f"Invalid config file '{yaml_path}': unable to read file: {e}. "
+            "See documentation/instructor_onboarding.md for supported schema/examples."
+        ) from e
     try:
         run_config = parse_run_config(raw_config)
     except ValueError as e:
@@ -315,7 +326,8 @@ def main() -> int:
             write_run_report(results, args)
             send_slack_run_summary(results, args, config)
 
-            if any(not r['success'] for r in results):
+            push_failed_total, _ = collect_push_failure_lines(results)
+            if any(not r['success'] for r in results) or push_failed_total > 0:
                 exit_code = 1
         except autograder_exceptions.AutograderError as e:
             log.error(e)

--- a/Autograder/reporting/reports.py
+++ b/Autograder/reporting/reports.py
@@ -198,11 +198,12 @@ def print_results_summary(results: List[Dict]) -> None:
     skipped_ungraded_total, skipped_ungraded_lines = (
         collect_push_skipped_ungraded_lines(results))
     if push_failed_total > 0:
-        log.warning(
-            f"Detected {push_failed_total} per-student push failure(s) across successful assignments."
+        log.error(
+            f"Detected {push_failed_total} per-student push failure(s) across successful assignments. "
+            "This run will return a non-zero exit code."
         )
         for line in push_failure_lines:
-            log.warning(line)
+            log.error(line)
     if skipped_ungraded_total > 0:
         log.warning(
             f"Detected {skipped_ungraded_total} per-student ungraded skip(s) across successful assignments."

--- a/documentation/operations_runbook.md
+++ b/documentation/operations_runbook.md
@@ -2,6 +2,12 @@
 
 This runbook covers how to diagnose and recover from failed or partial grading runs.
 
+## Release Notes (Operator-facing)
+
+- Run exit code is now non-zero when there are any assignment failures or any per-student push failures.
+- Slack notifications stay aggregated at run level (single summary message), including push-failure details.
+- Default log directory selection is: `/var/log/grading` -> `~/.autograder/logs` -> `/tmp/autograder/logs` (not the current working directory).
+
 ## Before Running
 
 1. Start with a limited run:

--- a/documentation/troubleshooting.md
+++ b/documentation/troubleshooting.md
@@ -98,6 +98,7 @@ This guide covers common runtime failures and the fastest way to recover.
 
 - rerun with `--idempotency-key` to skip already-pushed submissions.
 - inspect `run-report.json` for `push_failed_students`.
+- runs with any push failures now return a non-zero exit code (while still aggregating failures into one run-level summary/Slack alert).
 
 ## Records / Idempotency Path Issues
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,14 +25,14 @@ dependencies = [
     "python-dotenv==1.0.1",
     "PyYAML==6.0.1",
     "requests==2.32.2",
-    "canvasapi",
-    "python-dateutil",
-    "httpx>=0.25.2",
-    "docker>=6.1.3",
-    "slack-sdk>=3.36.0",
-    "openai",
-    "anthropic",
-    "ollama>=0.6.0",
+    "canvasapi~=3.2",
+    "python-dateutil~=2.9",
+    "httpx~=0.28",
+    "docker~=7.1",
+    "slack-sdk~=3.36",
+    "openai~=1.93",
+    "anthropic~=0.57",
+    "ollama~=0.6",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_grade_assignments_guards.py
+++ b/tests/test_grade_assignments_guards.py
@@ -262,6 +262,19 @@ def test_load_and_validate_config_error_includes_path_and_docs(tmp_path):
   assert "documentation/instructor_onboarding.md" in message
 
 
+def test_load_and_validate_config_yaml_parse_error_includes_path_and_docs(tmp_path):
+  yaml_file = tmp_path / "broken_syntax.yaml"
+  yaml_file.write_text("assignment_types:\n  x: [\n", encoding="utf-8")
+
+  with pytest.raises(SystemExit) as exc:
+    grade_assignments.load_and_validate_config(str(yaml_file))
+
+  message = str(exc.value)
+  assert str(yaml_file) in message
+  assert "YAML parse error" in message
+  assert "documentation/instructor_onboarding.md" in message
+
+
 def test_record_retention_requires_explicit_records_dir(monkeypatch):
   class DummyAssignment:
     def __init__(self):
@@ -1069,6 +1082,67 @@ privacy_mode: blind
   assert calls["push_flag"] is True
   assert calls["cleanup"] == 1
   assert calls["docker_cleanup"] == 1
+
+
+def test_main_returns_nonzero_when_push_failures_present(monkeypatch):
+  args = SimpleNamespace(
+    yaml="config.yaml",
+    env=None,
+    limit=None,
+    do_regrade=False,
+    max_workers=1,
+    test=False,
+    report=None,
+    error_slack_channel=None,
+    debug=False,
+    show_stage_timings=False,
+    reveal_identity=False,
+    idempotency_key=None,
+    idempotency_state_dir=None,
+    dump_config=False,
+    dry_run=False,
+    list_graders=False,
+  )
+
+  cleaned = {"called": False}
+
+  @contextlib.contextmanager
+  def fake_lock():
+    yield
+
+  results = [{
+    "success": True,
+    "assignment_id": 42,
+    "assignment_name": "PA1",
+    "course_name": "CST334",
+    "finalize_summary": {
+      "push_failed": 1,
+      "push_failed_students": ["Student 1"],
+    },
+  }]
+
+  monkeypatch.setattr(grade_assignments, "parse_args", lambda: args)
+  monkeypatch.setattr(grade_assignments, "ensure_single_instance", fake_lock)
+  monkeypatch.setattr(grade_assignments, "load_and_validate_config",
+                      lambda _: RunConfig())
+  monkeypatch.setattr(grade_assignments, "collect_assignments_to_grade",
+                      lambda _config, _args: [])
+  monkeypatch.setattr(grade_assignments, "execute_grading",
+                      lambda _assignments, _args: results)
+  monkeypatch.setattr(grade_assignments, "print_results_summary",
+                      lambda _results: None)
+  monkeypatch.setattr(grade_assignments, "write_run_report",
+                      lambda _results, _args: None)
+  monkeypatch.setattr(grade_assignments, "send_slack_run_summary",
+                      lambda _results, _args, _config: None)
+  monkeypatch.setattr(
+    grade_assignments.DockerClient, "cleanup",
+    lambda: cleaned.__setitem__("called", True))
+
+  exit_code = grade_assignments.main()
+
+  assert exit_code == 1
+  assert cleaned["called"] is True
 
 
 def test_send_slack_run_summary_notifies_on_push_failures(monkeypatch):

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,0 +1,40 @@
+import os
+
+import Autograder
+
+
+def test_setup_logging_falls_back_outside_working_directory(monkeypatch, tmp_path):
+  run_dir = tmp_path / "run-dir"
+  run_dir.mkdir()
+  monkeypatch.chdir(run_dir)
+  monkeypatch.delenv("LOG_DIR", raising=False)
+
+  home_fallback = os.path.abspath(os.path.expanduser("~/.autograder/logs"))
+  original_exists = Autograder.os.path.exists
+
+  def fake_isdir(path):
+    return path != "/var/log/grading"
+
+  def fake_access(path, mode):
+    return path != "/var/log/grading"
+
+  def fake_makedirs(path, exist_ok=False):
+    if path == "/var/log/grading":
+      raise OSError("permission denied")
+    return None
+
+  def fake_exists(path):
+    if str(path).endswith("logging.yaml"):
+      return False
+    return original_exists(path)
+
+  monkeypatch.setattr(Autograder.os.path, "isdir", fake_isdir)
+  monkeypatch.setattr(Autograder.os, "access", fake_access)
+  monkeypatch.setattr(Autograder.os, "makedirs", fake_makedirs)
+  monkeypatch.setattr(Autograder.os.path, "exists", fake_exists)
+  monkeypatch.setattr(Autograder.logging, "basicConfig", lambda **kwargs: None)
+
+  Autograder.setup_logging()
+
+  assert os.environ["LOG_DIR"] == home_fallback
+  assert os.environ["LOG_DIR"] != str(run_dir)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -320,19 +320,19 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic" },
-    { name = "canvasapi" },
-    { name = "docker", specifier = ">=6.1.3" },
-    { name = "httpx", specifier = ">=0.25.2" },
+    { name = "anthropic", specifier = "~=0.57" },
+    { name = "canvasapi", specifier = "~=3.2" },
+    { name = "docker", specifier = "~=7.1" },
+    { name = "httpx", specifier = "~=0.28" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.112.0" },
-    { name = "ollama", specifier = ">=0.6.0" },
-    { name = "openai" },
+    { name = "ollama", specifier = "~=0.6" },
+    { name = "openai", specifier = "~=1.93" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.3" },
-    { name = "python-dateutil" },
+    { name = "python-dateutil", specifier = "~=2.9" },
     { name = "python-dotenv", specifier = "==1.0.1" },
     { name = "pyyaml", specifier = "==6.0.1" },
     { name = "requests", specifier = "==2.32.2" },
-    { name = "slack-sdk", specifier = ">=3.36.0" },
+    { name = "slack-sdk", specifier = "~=3.36" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
Summary\n- gate release publishing behind a required checks job (hygiene + test suite)\n- treat per-student push failures as run failures (non-zero exit) while keeping aggregated run-level reporting/Slack\n- improve YAML config parse error handling with clearer user-facing messages\n- bound key runtime dependencies with compatible-release specifiers and refresh uv.lock\n- fix logging fallback so default logs do not go to the current working directory\n- document the new push-failure exit behavior in troubleshooting/runbook docs\n\nValidation\n- uv run pytest -q\n- uv run pytest tests/test_grade_assignments_guards.py tests/test_logging_setup.py -q\n- uv build\n